### PR TITLE
Add config-driven loop and watcher settings

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "nudge_interval_seconds": 60,
+  "incoming_folder": "incoming"
+}

--- a/loop.py
+++ b/loop.py
@@ -1,0 +1,41 @@
+"""Main loop for processing incoming files based on the JSON configuration."""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+from watcher import Watcher, load_config
+
+
+def _resolve_interval(config: Dict[str, Any]) -> float:
+    try:
+        interval = float(config["nudge_interval_seconds"])
+    except KeyError as exc:
+        raise KeyError("Missing 'nudge_interval_seconds' in configuration") from exc
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Configuration value 'nudge_interval_seconds' must be numeric") from exc
+
+    if interval <= 0:
+        raise ValueError("Configuration value 'nudge_interval_seconds' must be greater than zero")
+
+    return interval
+
+
+def main(config_path: Path | None = None) -> None:
+    """Run the processing loop using the configuration file."""
+    config = load_config(config_path)
+    interval = _resolve_interval(config)
+
+    watcher = Watcher.from_config(config)
+
+    while True:
+        new_files = watcher.scan()
+        if new_files:
+            for file_path in new_files:
+                print(f"Processing {file_path}")
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/watcher.py
+++ b/watcher.py
@@ -1,0 +1,61 @@
+"""File system watcher that relies on a shared JSON configuration."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().with_name("config.json")
+
+
+class Watcher:
+    """Monitor a directory for new files.
+
+    The watcher reads its target directory from the shared configuration so that
+    both the watcher and any client loops work from the same settings.
+    """
+
+    def __init__(self, incoming_folder: Path) -> None:
+        self.incoming_folder = incoming_folder
+        self._seen_files: set[Path] = set()
+        self.incoming_folder.mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "Watcher":
+        """Create a watcher instance using configuration values."""
+        try:
+            folder_value = config["incoming_folder"]
+        except KeyError as exc:
+            raise KeyError("Missing 'incoming_folder' in configuration") from exc
+
+        incoming_folder = Path(str(folder_value)).expanduser()
+        if not incoming_folder.is_absolute():
+            incoming_folder = DEFAULT_CONFIG_PATH.parent / incoming_folder
+
+        incoming_folder = incoming_folder.resolve()
+        return cls(incoming_folder)
+
+    def scan(self) -> List[Path]:
+        """Return any new files discovered in the incoming directory."""
+        discovered: List[Path] = []
+        for file_path in self._iter_candidate_files():
+            if file_path not in self._seen_files:
+                self._seen_files.add(file_path)
+                discovered.append(file_path)
+        return discovered
+
+    def _iter_candidate_files(self) -> Iterable[Path]:
+        if not self.incoming_folder.exists():
+            return ()
+
+        for path in self.incoming_folder.iterdir():
+            if path.is_file():
+                yield path
+
+
+def load_config(config_path: Path | None = None) -> Dict[str, Any]:
+    """Load configuration from JSON file."""
+    path = Path(config_path) if config_path else DEFAULT_CONFIG_PATH
+    with path.open("r", encoding="utf-8") as config_file:
+        return json.load(config_file)


### PR DESCRIPTION
## Summary
- add a shared `config.json` for the loop and watcher settings
- update the loop to load its nudge interval and watcher configuration from JSON
- update the watcher to consume the shared configuration and prepare the incoming folder

## Testing
- python -m compileall loop.py watcher.py *(fails: pyenv reports Python 3.11.9 is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ad33f72c832581aa0e165a33ed84