### PR TITLE
Add XP seeding utility and flow harness

### DIFF
--- a/seed.py
+++ b/seed.py
@@ -1,0 +1,184 @@
+"""Utility script for seeding experience points into the Kor'tana database."""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_AMOUNTS: dict[str, int] = {"focus": 1, "bond": 1, "relief": 1}
+SUPPORTED_FIELDS = set(DEFAULT_AMOUNTS)
+
+
+@dataclass(slots=True, frozen=True)
+class SeedResult:
+    """Structured return type for seed operations."""
+
+    focus: int
+    bond: int
+    relief: int
+    log_id: int
+
+    def as_dict(self) -> dict[str, int]:
+        return {"focus": self.focus, "bond": self.bond, "relief": self.relief}
+
+
+def _ensure_tables(connection: sqlite3.Connection) -> None:
+    """Create tables used for XP tracking if they do not already exist."""
+
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS xp_totals (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            focus INTEGER NOT NULL DEFAULT 0,
+            bond INTEGER NOT NULL DEFAULT 0,
+            relief INTEGER NOT NULL DEFAULT 0
+        )
+        """
+    )
+    connection.execute("INSERT OR IGNORE INTO xp_totals (id) VALUES (1)")
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS xp_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_type TEXT NOT NULL,
+            focus INTEGER NOT NULL,
+            bond INTEGER NOT NULL,
+            relief INTEGER NOT NULL,
+            payload TEXT,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+
+
+def _coerce_amounts(pairs: Iterable[str]) -> dict[str, int]:
+    """Parse CLI pairs like ("focus", "5") into a dictionary."""
+
+    amounts: dict[str, int] = {}
+    iterator = iter(pairs)
+    for key in iterator:
+        try:
+            value = next(iterator)
+        except StopIteration as exc:  # pragma: no cover - defensive guard
+            raise ValueError("XP arguments must be provided in <name> <amount> pairs") from exc
+
+        field = key.lower()
+        if field not in SUPPORTED_FIELDS:
+            raise ValueError(
+                f"Unsupported XP field '{key}'. Supported fields: {', '.join(sorted(SUPPORTED_FIELDS))}."
+            )
+
+        try:
+            amounts[field] = int(value)
+        except ValueError as exc:  # pragma: no cover - validated by argparse
+            raise ValueError(f"Amount for '{key}' must be an integer, got: {value!r}") from exc
+
+    return amounts
+
+
+def seed_xp(db_path: str | Path = "kortana.db", amounts: dict[str, int] | None = None) -> SeedResult:
+    """Seed experience points into the database.
+
+    Args:
+        db_path: Path to the SQLite database.
+        amounts: Optional mapping of XP increments.
+
+    Returns:
+        SeedResult describing the totals after seeding and log identifier.
+    """
+
+    increments = {**DEFAULT_AMOUNTS}
+    if amounts:
+        increments.update(amounts)
+
+    db_location = Path(db_path)
+    db_location.parent.mkdir(parents=True, exist_ok=True)
+
+    with sqlite3.connect(db_location) as connection:
+        connection.row_factory = sqlite3.Row
+        _ensure_tables(connection)
+
+        connection.execute(
+            """
+            UPDATE xp_totals
+            SET focus = focus + ?,
+                bond = bond + ?,
+                relief = relief + ?
+            WHERE id = 1
+            """,
+            (
+                increments["focus"],
+                increments["bond"],
+                increments["relief"],
+            ),
+        )
+
+        row = connection.execute(
+            "SELECT focus, bond, relief FROM xp_totals WHERE id = 1"
+        ).fetchone()
+        assert row is not None, "xp_totals should always contain row with id=1"
+
+        payload = json.dumps({"increments": increments})
+        timestamp = datetime.now(UTC).isoformat()
+        cursor = connection.execute(
+            """
+            INSERT INTO xp_logs (event_type, focus, bond, relief, payload, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "seed",
+                row["focus"],
+                row["bond"],
+                row["relief"],
+                payload,
+                timestamp,
+            ),
+        )
+
+    result = SeedResult(
+        focus=int(row["focus"]),
+        bond=int(row["bond"]),
+        relief=int(row["relief"]),
+        log_id=cursor.lastrowid,
+    )
+
+    print(
+        "[XP] Seed complete -> focus={focus}, bond={bond}, relief={relief}".format(
+            **result.as_dict()
+        )
+    )
+
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed XP totals for Kor'tana")
+    parser.add_argument(
+        "pairs",
+        nargs="*",
+        metavar=("field", "amount"),
+        help="Pairs of XP field names and integer amounts (e.g. focus 5 bond 2)",
+    )
+    parser.add_argument(
+        "--db",
+        default="kortana.db",
+        help="Path to the Kor'tana SQLite database (default: %(default)s)",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        user_amounts = _coerce_amounts(args.pairs) if args.pairs else None
+    except ValueError as exc:
+        parser.error(str(exc))
+        return
+
+    seed_xp(db_path=args.db, amounts=user_amounts)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_flow.py
+++ b/test_flow.py
@@ -1,0 +1,173 @@
+"""Integration harness for Kor'tana experience seeding and nudging."""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, Final
+
+try:  # Optional dependency for full configuration support
+    from config import load_config
+except Exception:  # pragma: no cover - falls back when config deps missing
+    load_config = None  # type: ignore[assignment]
+
+from seed import seed_xp
+from scripts.init_db import init_kortana_db
+
+_DB_DEFAULT: Final[str] = "kortana.db"
+
+
+def _get_connection(db_path: str | Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def get_totals(db_path: str | Path) -> dict[str, int]:
+    with _get_connection(db_path) as connection:
+        row = connection.execute(
+            "SELECT focus, bond, relief FROM xp_totals WHERE id = 1"
+        ).fetchone()
+    if row is None:
+        return {"focus": 0, "bond": 0, "relief": 0}
+    return {key: int(row[key]) for key in ("focus", "bond", "relief")}
+
+
+def get_next_nudge(db_path: str | Path) -> dict[str, Any]:
+    totals = get_totals(db_path)
+    dominant_metric = max(totals, key=totals.get)
+
+    motivations = {
+        "focus": "Channel the clarity you've been cultivating. Take a dedicated 5-minute scan of today's goals.",
+        "bond": "Reach out with a message of appreciation. Small acts grow the bond you value most.",
+        "relief": "Give yourself permission to breathe. A brief pause will amplify the calm you've earned.",
+    }
+
+    message = motivations.get(
+        dominant_metric,
+        "Notice how each stat is growing. Choose the one that resonates and give it attention today.",
+    )
+
+    return {
+        "totals": totals,
+        "dominant": dominant_metric,
+        "message": message,
+    }
+
+
+def push_notification(nudge: dict[str, Any]) -> None:
+    print("\n[NOTIFICATION]")
+    print(f"Dominant focus: {nudge['dominant']}")
+    print(nudge["message"])
+
+
+def _iter_logs(connection: sqlite3.Connection, limit: int) -> Iterable[sqlite3.Row]:
+    cursor = connection.execute(
+        """
+        SELECT id, event_type, focus, bond, relief, payload, created_at
+        FROM xp_logs
+        ORDER BY id DESC
+        LIMIT ?
+        """,
+        (limit,),
+    )
+    rows = cursor.fetchall()
+    # Display oldest first within the limited window for readability
+    return reversed(rows)
+
+
+def print_logs(db_path: str | Path, limit: int) -> None:
+    print("\n[XP LOGS]")
+    with _get_connection(db_path) as connection:
+        rows = list(_iter_logs(connection, limit))
+        if not rows:
+            print("No XP log entries recorded yet.")
+            return
+        for row in rows:
+            payload = json.loads(row["payload"]) if row["payload"] else {}
+            increments = payload.get("increments", {})
+            print(
+                f"#{row['id']:03d} {row['created_at']} "
+                f"event={row['event_type']} totals(focus={row['focus']}, bond={row['bond']}, relief={row['relief']}) "
+                f"delta={increments}"
+            )
+
+
+def _resolve_log_limit(config_obj: Any) -> int:
+    if config_obj is None:
+        return 50
+
+    for attribute in ("log_limit",):
+        if hasattr(config_obj, attribute):
+            value = getattr(config_obj, attribute)
+            if isinstance(value, int) and value > 0:
+                return value
+
+    if hasattr(config_obj, "logging") and hasattr(config_obj.logging, "log_limit"):
+        value = getattr(config_obj.logging, "log_limit")
+        if isinstance(value, int) and value > 0:
+            return value
+
+    return 50
+
+
+def run_flow(db_path: str | Path, seed_overrides: dict[str, int] | None = None) -> None:
+    config_obj = load_config() if callable(load_config) else None
+    log_limit = _resolve_log_limit(config_obj)
+
+    print("[STEP] init_db()")
+    init_kortana_db(str(db_path))
+
+    print("[STEP] seed.py")
+    result = seed_xp(db_path=db_path, amounts=seed_overrides)
+
+    print("[STEP] get_next_nudge()")
+    nudge = get_next_nudge(db_path)
+
+    print("[STEP] push_notification()")
+    push_notification(nudge)
+
+    print_logs(db_path, log_limit)
+
+    print(
+        "focus={focus}, bond={bond}, relief={relief}".format(
+            focus=result.focus,
+            bond=result.bond,
+            relief=result.relief,
+        )
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the Kor'tana XP flow test")
+    parser.add_argument(
+        "--db",
+        default=_DB_DEFAULT,
+        help="Path to the Kor'tana SQLite database (default: %(default)s)",
+    )
+    parser.add_argument(
+        "pairs",
+        nargs="*",
+        metavar=("field", "amount"),
+        help="Optional XP overrides passed to seed.py (e.g. focus 5 bond 3)",
+    )
+
+    args = parser.parse_args()
+
+    seed_overrides = None
+    if args.pairs:
+        from seed import _coerce_amounts  # Lazy import to keep CLI parsing aligned
+
+        try:
+            seed_overrides = _coerce_amounts(args.pairs)
+        except ValueError as exc:
+            parser.error(str(exc))
+            return
+
+    run_flow(Path(args.db), seed_overrides)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a seed.py utility that records XP totals and logs seed events with optional CLI overrides
- create test_flow.py harness that initializes the database, seeds XP, computes nudges, pushes notifications, and prints logs within config limits

## Testing
- python3 test_flow.py --db kortana.db

------
https://chatgpt.com/codex/tasks/task_e_68d8ae76c3a88325a74c992291154ced